### PR TITLE
[systemd][opennsl]: change the opnensl-modules service dependency

### DIFF
--- a/systemd/opennsl-modules.service
+++ b/systemd/opennsl-modules.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Opennsl kernel modules init
-After=local-fs.target
+After=rc-local.service
 Before=syncd.service
 
 [Service]


### PR DESCRIPTION
opennsl modules were starting too soon (prior to rc-local.service).  Platform dpkg of LAZY_INSTALL debian is done during rc-local.service.  When platform contains services that must run prior to opennsl, there is no way to ensure that dependency.  By starting opennsl after rc-local, we can ensure that platform specific services have a chance to insert themselves accordingly.
