### PR TITLE
Update bcm-ptp-clock for 5.10 kernel compilation

### DIFF
--- a/systems/linux/kernel/modules/bcm-ptp-clock/Makefile
+++ b/systems/linux/kernel/modules/bcm-ptp-clock/Makefile
@@ -36,7 +36,7 @@ KMODULE = $(LIBDIR)/$(THIS_MOD_NAME).ko
 build: $(MODULE) $(KMODULE)
 endif
 
-#KBUILD_EXTRA_SYMBOLS := ${BLDDIR}/../../../../bde/linux/kernel/kernel_module/Module.symvers
+KBUILD_EXTRA_SYMBOLS := ${BLDDIR}/../../../../bde/linux/kernel/kernel_module/Module.symvers
 KBUILD_EXTRA_SYMBOLS += ${BLDDIR}/../bcm-knet/kernel_module/Module.symvers
 
 # BCM PTP Clock Device
@@ -49,7 +49,7 @@ $(KMODULE): $(MODULE)
 	mkdir $(BLDDIR)/$(KERNEL_MODULE_DIR)
 	cp ${SDK}/make/Makefile.linux-kmodule $(BLDDIR)/$(KERNEL_MODULE_DIR)/Makefile
 	cat ${KBUILD_EXTRA_SYMBOLS} > $(BLDDIR)/$(KERNEL_MODULE_DIR)/Module.symvers
-	MOD_NAME=$(THIS_MOD_NAME) $(MAKE) -C $(BLDDIR)/$(KERNEL_MODULE_DIR) $(THIS_MOD_NAME).ko
+	MOD_NAME=$(THIS_MOD_NAME) KBUILD_EXTRA_SYMBOLS="${KBUILD_EXTRA_SYMBOLS}" $(MAKE) -C $(BLDDIR)/$(KERNEL_MODULE_DIR) $(THIS_MOD_NAME).ko
 endif
 
 # Make.depend is before clean:: so that Make.depend's clean:: runs first.


### PR DESCRIPTION
KBUILD_EXTRA_SYMBOLS needs to be set as an environment variable

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>