### PR TITLE
[bcm-knet] Crash patch

### DIFF
--- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -7829,7 +7829,7 @@ cfg_api_lock(bkn_switch_info_t *sinfo, unsigned long *flags)
     spin_lock_irqsave(&sinfo->lock, *flags);
     while (sinfo->cfg_api_locked) {
         spin_unlock_irqrestore(&sinfo->lock, *flags);
-        while (sinfo->cfg_api_locked);
+        while (sinfo->cfg_api_locked) { schedule(); } /* SDK-268597 */
         spin_lock_irqsave(&sinfo->lock, *flags);
     }
 }


### PR DESCRIPTION
Patch for occasional kernel crash

ov  4 22:12:34.806108 str2-lc3-1 WARNING kernel: [ 5873.485991]  ? cfg_api_lock+0x32/0x43 [linux_bcm_knet]
Nov  4 22:12:34.806111 str2-lc3-1 WARNING kernel: [ 5873.485998]  ? _ioctl+0x1745/0x23ba [linux_bcm_knet]
Nov  4 22:12:34.806113 str2-lc3-1 WARNING kernel: [ 5873.486008]  ? update_blocked_averages+0x861/0xa60
Nov  4 22:12:34.806116 str2-lc3-1 WARNING kernel: [ 5873.486012]  ? __update_load_avg_cfs_rq+0x1f6/0x270
Nov  4 22:12:34.806118 str2-lc3-1 WARNING kernel: [ 5873.486015]  ? update_group_capacity+0x23/0x2a0
Nov  4 22:12:34.806120 str2-lc3-1 WARNING kernel: [ 5873.486018]  ? cpumask_next_and+0x19/0x20
Nov  4 22:12:34.806122 str2-lc3-1 WARNING kernel: [ 5873.486021]  ? find_busiest_group+0x12d/0xb10
Nov  4 22:12:34.806127 str2-lc3-1 WARNING kernel: [ 5873.486025]  ? cpumask_next_wrap+0x2c/0x70
Nov  4 22:12:34.806129 str2-lc3-1 WARNING kernel: [ 5873.486028]  ? __update_load_avg_cfs_rq+0x1f6/0x270
Nov  4 22:12:34.806130 str2-lc3-1 WARNING kernel: [ 5873.486031]  ? select_idle_sibling+0x22/0x3a0
Nov  4 22:12:34.806132 str2-lc3-1 WARNING kernel: [ 5873.486034]  ? update_load_avg+0x89/0x5e0
Nov  4 22:12:34.806134 str2-lc3-1 WARNING kernel: [ 5873.486037]  ? account_entity_enqueue+0xc5/0xf0
Nov  4 22:12:34.806136 str2-lc3-1 WARNING kernel: [ 5873.486039]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806139 str2-lc3-1 WARNING kernel: [ 5873.486040]  ? __switch_to_asm+0x35/0x70
Nov  4 22:12:34.806141 str2-lc3-1 WARNING kernel: [ 5873.486042]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806143 str2-lc3-1 WARNING kernel: [ 5873.486044]  ? __switch_to_asm+0x35/0x70
Nov  4 22:12:34.806145 str2-lc3-1 WARNING kernel: [ 5873.486045]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806147 str2-lc3-1 WARNING kernel: [ 5873.486047]  ? __switch_to_asm+0x35/0x70
Nov  4 22:12:34.806149 str2-lc3-1 WARNING kernel: [ 5873.486049]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806151 str2-lc3-1 WARNING kernel: [ 5873.486050]  ? __switch_to_asm+0x35/0x70
Nov  4 22:12:34.806154 str2-lc3-1 WARNING kernel: [ 5873.486052]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806157 str2-lc3-1 WARNING kernel: [ 5873.486053]  ? __switch_to_asm+0x35/0x70
Nov  4 22:12:34.806158 str2-lc3-1 WARNING kernel: [ 5873.486055]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806160 str2-lc3-1 WARNING kernel: [ 5873.486059]  ? ep_poll_callback+0x8c/0x2e0
Nov  4 22:12:34.806162 str2-lc3-1 WARNING kernel: [ 5873.486061]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806164 str2-lc3-1 WARNING kernel: [ 5873.486062]  ? __switch_to_asm+0x35/0x70
Nov  4 22:12:34.806168 str2-lc3-1 WARNING kernel: [ 5873.486064]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806170 str2-lc3-1 WARNING kernel: [ 5873.486065]  ? __switch_to_asm+0x35/0x70
Nov  4 22:12:34.806172 str2-lc3-1 WARNING kernel: [ 5873.486067]  ? __switch_to_asm+0x41/0x70
Nov  4 22:12:34.806174 str2-lc3-1 WARNING kernel: [ 5873.486070]  ? __wake_up_common+0x7a/0x190
Nov  4 22:12:34.806176 str2-lc3-1 WARNING kernel: [ 5873.486072]  ? __wake_up_common_lock+0x89/0xc0
Nov  4 22:12:34.806177 str2-lc3-1 WARNING kernel: [ 5873.486075]  ? select_idle_sibling+0x22/0x3a0
Nov  4 22:12:34.806179 str2-lc3-1 WARNING kernel: [ 5873.486078]  ? select_task_rq_fair+0x214/0xcc0
Nov  4 22:12:34.806183 str2-lc3-1 WARNING kernel: [ 5873.486082]  ? get_page_from_freelist+0x816/0x11b0
Nov  4 22:12:34.806185 str2-lc3-1 WARNING kernel: [ 5873.486087]  ? drain_stock.isra.39+0x32/0xb0
Nov  4 22:12:34.806187 str2-lc3-1 WARNING kernel: [ 5873.486090]  ? mem_cgroup_commit_charge+0x7a/0x560
Nov  4 22:12:34.806189 str2-lc3-1 WARNING kernel: [ 5873.486092]  ? mem_cgroup_try_charge+0x86/0x190
Nov  4 22:12:34.806190 str2-lc3-1 WARNING kernel: [ 5873.486096]  ? mem_cgroup_throttle_swaprate+0x24/0x14a
Nov  4 22:12:34.806192 str2-lc3-1 WARNING kernel: [ 5873.486099]  ? __handle_mm_fault+0xa98/0x11f0
Nov  4 22:12:34.806196 str2-lc3-1 WARNING kernel: [ 5873.486106]  ? _gmodule_unlocked_ioctl+0x18/0x21 [linux_bcm_knet]
Nov  4 22:12:34.806198 str2-lc3-1 WARNING kernel: [ 5873.486109]  ? do_vfs_ioctl+0xa4/0x630
Nov  4 22:12:34.806199 str2-lc3-1 WARNING kernel: [ 5873.486112]  ? recalc_sigpending+0x17/0x50
Nov  4 22:12:34.806201 str2-lc3-1 WARNING kernel: [ 5873.486114]  ? __set_task_blocked+0x6d/0x90
Nov  4 22:12:34.806203 str2-lc3-1 WARNING kernel: [ 5873.486116]  ? handle_mm_fault+0xd6/0x200
Nov  4 22:12:34.806204 str2-lc3-1 WARNING kernel: [ 5873.486118]  ? ksys_ioctl+0x60/0x90
Nov  4 22:12:34.806206 str2-lc3-1 WARNING kernel: [ 5873.486121]  ? __x64_sys_ioctl+0x16/0x20
Nov  4 22:12:34.806210 str2-lc3-1 WARNING kernel: [ 5873.486124]  ? do_syscall_64+0x53/0x110
Nov  4 22:12:34.806212 str2-lc3-1 WARNING kernel: [ 5873.486126]  ? entry_SYSCALL_64_after_hwframe+0x44/0xa9