### PR TITLE
Linux 6.1.94 update

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,5 +10,5 @@ Standards-Version: 3.9.3
 Package: opennsl-modules
 Architecture: amd64
 Section: main
-Depends: linux-image-6.1.0-11-2-amd64-unsigned
+Depends: linux-image-6.1.0-22-2-amd64-unsigned
 Description: kernel modules for broadcom SAI

--- a/debian/opennsl-modules.dirs
+++ b/debian/opennsl-modules.dirs
@@ -1,1 +1,1 @@
-lib/modules/6.1.0-11-2-amd64/extra
+lib/modules/6.1.0-22-2-amd64/extra

--- a/debian/opennsl-modules.install
+++ b/debian/opennsl-modules.install
@@ -1,6 +1,6 @@
-systems/linux/user/x86-smp_generic_64-2_6/linux-bcm-knet.ko lib/modules/6.1.0-11-2-amd64/extra
-systems/linux/user/x86-smp_generic_64-2_6/linux-kernel-bde.ko lib/modules/6.1.0-11-2-amd64/extra
-systems/linux/user/x86-smp_generic_64-2_6/linux-user-bde.ko lib/modules/6.1.0-11-2-amd64/extra
-systems/linux/user/x86-smp_generic_64-2_6/linux-knet-cb.ko lib/modules/6.1.0-11-2-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-bcm-knet.ko lib/modules/6.1.0-22-2-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-kernel-bde.ko lib/modules/6.1.0-22-2-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-user-bde.ko lib/modules/6.1.0-22-2-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-knet-cb.ko lib/modules/6.1.0-22-2-amd64/extra
 systemd/opennsl-modules.service lib/systemd/system
-sdklt/linux/bde/linux_ngbde.ko lib/modules/6.1.0-11-2-amd64/extra
+sdklt/linux/bde/linux_ngbde.ko lib/modules/6.1.0-22-2-amd64/extra

--- a/debian/rules
+++ b/debian/rules
@@ -34,8 +34,8 @@ sname:=opennsl
 PACKAGE=opennsl-modules
 # modifieable for experiments or debugging m-a
 MA_DIR ?= /usr/share/modass
-KVERSION ?= 6.1.0-11-2-amd64
-KERNVERSION ?= 6.1.0-11-2
+KVERSION ?= 6.1.0-22-2-amd64
+KERNVERSION ?= 6.1.0-22-2
 
 # load generic variable handling
 -include $(MA_DIR)/include/generic.make


### PR DESCRIPTION
Update the DNX kernel module to compile with Linux 6.1.94.

This is in connection with sonic-net/sonic-buildimage#19564.