### PR TITLE
Update the linux version to 6.12.41+deb13 in BCM opennsl/GPL debian files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,5 +10,5 @@ Standards-Version: 3.9.3
 Package: opennsl-modules
 Architecture: amd64
 Section: main
-Depends: linux-image-6.12.41-sonic-amd64-unsigned
+Depends: linux-image-6.12.41+deb13-sonic-amd64-unsigned
 Description: kernel modules for broadcom SAI

--- a/debian/opennsl-modules.install
+++ b/debian/opennsl-modules.install
@@ -1,6 +1,6 @@
-systems/linux/user/x86-smp_generic_64-2_6/linux-bcm-knet.ko lib/modules/6.12.41-sonic-amd64/extra
-systems/linux/user/x86-smp_generic_64-2_6/linux-kernel-bde.ko lib/modules/6.12.41-sonic-amd64/extra
-systems/linux/user/x86-smp_generic_64-2_6/linux-user-bde.ko lib/modules/6.12.41-sonic-amd64/extra
-systems/linux/user/x86-smp_generic_64-2_6/linux-knet-cb.ko lib/modules/6.12.41-sonic-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-bcm-knet.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-kernel-bde.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-user-bde.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-knet-cb.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
 systemd/opennsl-modules.service lib/systemd/system
-sdklt/linux/bde/linux_ngbde.ko lib/modules/6.12.41-sonic-amd64/extra
+sdklt/linux/bde/linux_ngbde.ko lib/modules/6.12.41+deb13-sonic-amd64/extra


### PR DESCRIPTION
Issue:
The linux version in the host is 6.12.41+deb13, however the opennsl files were installed in 6.12.41 and causing dependency issues when the opennsl-modules-dnx_14.1.0.1.0.0.0.0_amd64.deb is installed . So the opennsl-modules.service is not installed and started and hence the swss/syncd dockers are not coming up

Fix:
Changed the kernel version to 6.12.41+deb13 in the saibcm-modules-dnx debian dependency and install files.