### PR TITLE
[XGS] Port 3 post-Mar25 fixes from sonic-buildimage master

### DIFF
--- a/debian/opennsl-modules.init
+++ b/debian/opennsl-modules.init
@@ -49,6 +49,7 @@ function load_kernel_modules()
         modprobe linux_ngbde
         modprobe linux_ngknet rx_buffer_size=$rx_buffer_size
         modprobe linux_ngknetcb
+        modprobe linux_bcmgenl
     else
         modprobe linux-kernel-bde dmasize=$dmasize maxpayload=128 debug=4 dma_debug=1 usemsi=$usemsi
         modprobe linux-user-bde
@@ -63,6 +64,7 @@ function load_kernel_modules()
 function remove_kernel_modules()
 {
     if [[ $is_ltsw_chip -eq 1 ]]; then
+        rmmod linux_bcmgenl
         rmmod linux_ngknetcb
         rmmod linux_ngknet
         rmmod linux_ngbde

--- a/debian/opennsl-modules.init
+++ b/debian/opennsl-modules.init
@@ -54,7 +54,7 @@ function load_kernel_modules()
         modprobe linux-user-bde
         modprobe psample
 
-        modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238 debug=0x5020 default_mtu=9100
+        modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238 debug=0x5020 default_mtu=9100 use_napi=$use_napi
         modprobe linux-knet-cb
         modprobe linux_ngbde
     fi
@@ -92,6 +92,7 @@ function load_platform_env()
     # Set the default configuration for dmasize and usemsi parameters
     dmasize=32M
     usemsi=0
+    use_napi=0
     is_ltsw_chip=0
     rx_buffer_size=9216
 

--- a/debian/opennsl-modules.install
+++ b/debian/opennsl-modules.install
@@ -6,3 +6,4 @@ systemd/opennsl-modules.service lib/systemd/system
 sdklt/build/bde/linux_ngbde.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
 sdklt/build/knet/linux_ngknet.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
 sdklt/build/knetcb/linux_ngknetcb.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
+sdklt/build/bcmgenl/linux_bcmgenl.ko lib/modules/6.12.41+deb13-sonic-amd64/extra

--- a/debian/rules
+++ b/debian/rules
@@ -89,14 +89,12 @@ build-arch-stamp:
 
 	# create links
 	cd /; sudo mkdir -p /lib/modules/$(KVER_ARCH)
-	cd /; sudo rm /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo rm /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
+	cd /; sudo ln -sf /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
 	cd /; sudo cp /usr/src/linux-headers-$(KVER_ARCH)/Module.symvers /usr/src/linux-headers-$(KVER_COMMON)/Module.symvers
 
 	# Add here command to compile/build the package.


### PR DESCRIPTION
#### Why I did it
Three commits landed on sonic-buildimage master that modified the inline `platform/broadcom/saibcm-modules/` directory after this submodule branch was first imported. Port them here so that PR sonic-net/sonic-buildimage#26388 (which converts the inline directory to this submodule) can move forward without losing those fixes.

Ported commits (in order):
- sonic-net/sonic-buildimage#26450 -- `debian/rules`: idempotent symlink creation (`ln -sf`/`ln -sfn`)
- sonic-net/sonic-buildimage#26206 -- `debian/opennsl-modules.init`: enable napi knob in `modprobe linux-bcm-knet`
- sonic-net/sonic-buildimage#26360 -- `debian/opennsl-modules.init` + `debian/opennsl-modules.install`: install and load `linux_bcmgenl`

#### How I did it
Replayed the post-image of each touched file at each upstream commit, one commit per upstream PR, preserving authorship intent.

#### How to verify it
Will be verified by the buildimage CI on sonic-net/sonic-buildimage#26388 once this is merged and the submodule pointer is bumped.

Signed-off-by: zitingguo <zitingguo@microsoft.com>