### PR TITLE
[legacy-TH] Port symlink idempotency fix from sonic-buildimage master

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -89,14 +89,12 @@ build-arch-stamp:
 
 	# create links
 	cd /; sudo mkdir -p /lib/modules/$(KVER_ARCH)
-	cd /; sudo rm /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo rm /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
+	cd /; sudo ln -sf /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
 	cd /; sudo cp /usr/src/linux-headers-$(KVER_ARCH)/Module.symvers /usr/src/linux-headers-$(KVER_COMMON)/Module.symvers
 
 	# Add here command to compile/build the package.


### PR DESCRIPTION
#### Why I did it
One commit landed on sonic-buildimage master that modified the inline `platform/broadcom/saibcm-modules-legacy-th/` directory after this submodule branch was first imported. Port it here so that PR sonic-net/sonic-buildimage#26389 (legacy-TH submodule conversion) can move forward.

Ported commit:
- sonic-net/sonic-buildimage#26450 -- `debian/rules`: idempotent symlink creation (`ln -sf`/`ln -sfn`)

This is the legacy-TH companion to sonic-net/saibcm-modules#36 (XGS non-TH).

#### How I did it
Replayed the post-image of `debian/rules` at upstream commit ab081ee.

#### How to verify it
Will be verified by the buildimage CI on sonic-net/sonic-buildimage#26389 once this is merged and the submodule pointer is bumped.

Signed-off-by: zitingguo <zitingguo@microsoft.com>