### PR TITLE
[bcm-genl] Restore DCBDIR path fallback

### DIFF
--- a/systems/linux/kernel/modules/bcm-genl/Makefile
+++ b/systems/linux/kernel/modules/bcm-genl/Makefile
@@ -35,7 +35,8 @@ include ${SDK}/make/Make.config
 LIBS = $(LIBDIR)/libkern.a
 
 ifndef DCBDIR
-$(error 'The $$DCBDIR variable is not set')
+DCBDIR = $(SDK)/systems/linux/kernel/modules/dcb
+# $(error 'The $$DCBDIR variable is not set')
 endif
 ifeq (1,$(NO_PRECOMPILED_MODULE))
 $(error 'DCB_LIB build is not supported if NO_PRECOMPILED_MODULE=1')


### PR DESCRIPTION
## Why

sdk-6.5.35-xgs unconditionally errors when `DCBDIR` is unset, which breaks the SONiC `opennsl-modules` deb build because `debian/rules` does not pass `DCBDIR` to the kernel-module make invocations:

`
Makefile:38: *** 'The $DCBDIR variable is not set'.  Stop.
make[5]: *** [.../Make.subdirs:40: bcm-genl] Error 2
`

## How

Restore the same path fallback that sdk-6.5.34-xgs and prior branches use:

`ifndef DCBDIR / DCBDIR = $(SDK)/systems/linux/kernel/modules/dcb / endif`

The `dcb/` source tree exists in this branch so the fallback path is valid. No behavior change for callers that already set DCBDIR; restores buildability when it's unset.

## Test

CI verification on sonic-net/sonic-buildimage#27465.

Signed-off-by: zitingguo <zitingguo@microsoft.com>