### PR TITLE
Bump up to SDK-6.5.35-dnx-gpl

### DIFF
--- a/include/ibde.h
+++ b/include/ibde.h
@@ -1,7 +1,7 @@
 /*
  * $Id: ibde.h,v 1.27 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/include/kcom.h
+++ b/include/kcom.h
@@ -1,6 +1,7 @@
 /*
  * $Id: kcom.h,v 1.9 Broadcom SDK $
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ *
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -209,6 +210,7 @@ typedef struct kcom_netif_s {
 
 #define KCOM_FILTER_F_ANY_DATA  (1U << 0)
 #define KCOM_FILTER_F_STRIP_TAG (1U << 1)
+#define KCOM_FILTER_F_OOB_RAW   (1U << 2)
 
 #define KCOM_FILTER_DESC_MAX    32
 

--- a/include/sal/types.h
+++ b/include/sal/types.h
@@ -1,7 +1,7 @@
 /*
  * $Id: types.h,v 1.3 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/include/sdk_config.h
+++ b/include/sdk_config.h
@@ -1,7 +1,7 @@
 /*
  * $Id: sdk_config.h,v 1.5 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/include/soc/devids.h
+++ b/include/soc/devids.h
@@ -1,7 +1,7 @@
 /*
  * $Id: devids.h,v 1.309 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -1767,17 +1767,14 @@
 #define BCM8879C_DEVICE_ID      0x879C
 #define BCM8879D_DEVICE_ID      0x879D
 #define BCM8879E_DEVICE_ID      0x879E
-#define BCM8879F_DEVICE_ID      0x879F  
+#define BCM8879F_DEVICE_ID      0x879F
 #ifdef BCM_DNXF3_SUPPORT
 #define RAMON2_DEVICE_ID      0x8910
 #define BCM8891F_DEVICE_ID      0x891F
 #define RAMON3_DEVICE_ID      0x8920
 #endif
-#ifdef BCM_DNXFE_SUPPORT
-#ifdef BCM_RAMON_4_SUPPORT
 #define RAMON4_DEVICE_ID      0x9470
-#endif
-#endif
+
 #define ARADPLUS_DEVICE_ID      0x8660
 #define ARADPLUS_A0_REV_ID      0x0001
 #define BCM88660_DEVICE_ID      ARADPLUS_DEVICE_ID
@@ -2086,24 +2083,24 @@
 #define Q3U_ORIG_DEVICE_ID      0x8400
 #define Q3N_ORIG_DEVICE_ID      0x8405
 #endif
-#ifdef BCM_JERICHO_4_SUPPORT
+
+
+
+
+
+#endif /* BCM_DNX3_SUPPORT */
+
+
 #define JERICHO4_DEVICE_ID      0x9450
 #define Q4_DEVICE_ID            0x9420
-#endif
-
-#ifdef BCM_Q4D_SUPPORT
 #define Q4D_DEVICE_ID           0x9430
-#define Q4D_PT200_START_DEVICE_ID  0x9436
-#define Q4D_PT200_END_DEVICE_ID 0x9439
-#endif
-
-
-#ifdef BCM_J4L_SUPPORT
+#define Q4D_200G_START_DEVICE_ID  0x9436
+#define Q4D_200G_END_DEVICE_ID    0x9439
 #define J4L_DEVICE_ID           0x9410
-#endif
+#define Q4DL_DEVICE_ID          0x94E0
+#define Q4DL_200G_START_DEVICE_ID  0x94E6
+#define Q4DL_200G_END_DEVICE_ID    0x94E9
 
-
-#endif
 #define Q2A_DEVICE_ID           0x8480
 #define Q2A_A0_REV_ID           DNXC_A0_REV_ID
 #define Q2A_B0_REV_ID           DNXC_B0_REV_ID
@@ -2243,7 +2240,7 @@
 
 #define PLX9056_DEVICE_ID       0x9056 /* needed for DNX_TEST_BOARD */
 
-/* Tomahawk F1 */
+/* Tomahawk Ultra */
 #define BCM78920_DEVICE_ID 0xf920
 #define BCM78920_A0_REV_ID 0x0001
 #define BCM78923_DEVICE_ID 0xf923
@@ -2252,6 +2249,12 @@
 #define BCM78924_A0_REV_ID 0x0001
 #define BCM78928_DEVICE_ID 0xf928
 #define BCM78928_A0_REV_ID 0x0001
+
+/* Tomahawk Ultra */
+#define BCM78920_B0_REV_ID 0x0011
+#define BCM78923_B0_REV_ID 0x0011
+#define BCM78924_B0_REV_ID 0x0011
+#define BCM78928_B0_REV_ID 0x0011
 
 /* Trident4 X11c */
 #define BCM56890_DEVICE_ID 0xb890

--- a/make/Make.clang
+++ b/make/Make.clang
@@ -1,6 +1,6 @@
 # $Id: Make.clang
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Make.config
+++ b/make/Make.config
@@ -1,6 +1,6 @@
 # $Id: Make.config,v 1.3 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.
@@ -83,25 +83,33 @@ endif # ALL_CHIPS
 
 ifdef ALL_DNX2_CHIPS
   CFGFLAGS += -DBCM_DNX_SUPPORT
-  CFGFLAGS += -DBCM_INSTANCE_SUPPORT
 endif
 
 ifdef ALL_DNX3_CHIPS
   CFGFLAGS += -DBCM_DNX3_SUPPORT
-  CFGFLAGS += -DBCM_INSTANCE_SUPPORT
 endif
 
 
 ifdef ALL_DNXF1_CHIPS
   CFGFLAGS += -DBCM_DNXF_SUPPORT
-  CFGFLAGS += -DBCM_INSTANCE_SUPPORT
 endif
 
 ifdef ALL_DNXF3_CHIPS
   CFGFLAGS += -DBCM_DNXF3_SUPPORT
-  CFGFLAGS += -DBCM_INSTANCE_SUPPORT
 endif
 
+ifdef ALL_DNXGEN4_CHIPS
+  CFGFLAGS += -DBCM_JERICHO_4_SUPPORT
+  CFGFLAGS += -DBCM_J4L_SUPPORT
+  CFGFLAGS += -DBCM_Q4D_SUPPORT
+  CFGFLAGS += -DBCM_Q4DL_SUPPORT
+endif
+
+CFGFLAGS += -DBCM_INSTANCE_SUPPORT
+# For PKTIO implementation files
+ifdef PKTIO_IMPL
+  CFGFLAGS += -DPKTIO_IMPL=1
+endif # PKTIO_IMPL
 
 #
 # By default, turn off the "changing directory" message.
@@ -213,12 +221,6 @@ CXXFLAGS += ${INCFLAGS}
 CPPFLAGS += ${INCFLAGS}
 
 CFLAGS += -DSAI_FIXUP -UKCOM_FILTER_MAX -DKCOM_FILTER_MAX=1025 -UKCOM_NETIF_MAX -DKCOM_NETIF_MAX=1056
-
-# Flags for DNX ASIC family
-CFLAGS += -DBCM_DNX_SUPPORT -DBCM_DNX2_SUPPORT -DBCM_DNXF_SUPPORT -DBCM_DNX3_SUPPORT
-#
-# # Flag to enable multi instance support
-CFLAGS += -DBCM_INSTANCE_SUPPORT
 
 #
 # Debug #ifdef control

--- a/make/Make.depend
+++ b/make/Make.depend
@@ -1,6 +1,6 @@
 # $Id: Make.depend,v 1.14 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Make.kernlib
+++ b/make/Make.kernlib
@@ -1,6 +1,6 @@
 # $Id: Make.kernlib,v 1.7 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Make.lib
+++ b/make/Make.lib
@@ -1,6 +1,6 @@
 # $Id: Make.lib,v 1.14 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Make.linux
+++ b/make/Make.linux
@@ -1,7 +1,7 @@
 #
 # $Id: Make.linux,v 1.18 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Make.subdirs
+++ b/make/Make.subdirs
@@ -1,6 +1,6 @@
 # $Id: Make.subdirs,v 1.8 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Make.tools
+++ b/make/Make.tools
@@ -1,6 +1,6 @@
 # $Id: Make.tools,v 1.2 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-gts
+++ b/make/Makefile.linux-gts
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-xlr-4_19,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-iproc
+++ b/make/Makefile.linux-iproc
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-iproc Exp $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.
@@ -33,6 +33,10 @@ ifeq (,$(BUILD_PLATFORM))
 BUILD_PLATFORM=ARM_LINUX
 endif
 
+# Upgrade TCL version from default 8.3 to 8.4
+# Because the incompatible-pointer-types warnings will be treated as errors in new toolchain.
+export TCL840 := 1
+
 # TOOLCHAIN_BASE_DIR    Toolchain base directory for iPROC-CMICd devices
 # TARGET_ARCHITECTURE   Compiler for target architecture
 # KERNDIR               Kernel directory for iPROC-CMICd devices
@@ -40,12 +44,12 @@ ifeq (BE,$(ENDIAN_MODE))
 #While BE mode is supported, it's use is very limited.  We had a specific customer
 #request for BE support but don't currently mainstream it.  So a 5.1.0 version
 #has not been built.  Continue using 5.0.3 for any BE support
-TOOLCHAIN_BASE_DIR ?= /projects/ntsw-tools/linux/iproc_ldks/xldk63-be/XLDK32
+TOOLCHAIN_BASE_DIR ?= /projects/ntsw-tools/linux/iproc_ldks/xldk64-be/XLDK32
 KERN_BASE_DIR ?= $(TOOLCHAIN_BASE_DIR)
 TARGET_ARCHITECTURE:=armeb-broadcom-linux-uclibcgnueabi
 KERNDIR ?= $(TOOLCHAIN_BASE_DIR)/kernel/linux
 else
-TOOLCHAIN_BASE_DIR ?= /projects/ntsw-tools/linux/iproc_ldks/xldk63/XLDK32
+TOOLCHAIN_BASE_DIR ?= /projects/ntsw-tools/linux/iproc_ldks/xldk64/XLDK32
 KERN_BASE_DIR ?= $(TOOLCHAIN_BASE_DIR)
 TARGET_ARCHITECTURE:= arm-broadcom-linux-uclibcgnueabi
 KERNDIR ?= $(KERN_BASE_DIR)/kernel/linux
@@ -116,7 +120,7 @@ modname_flags  = $(if $(filter 1,$(words $(modname))),\
 KFLAG_INCLD ?= $(LD_LIBRARY_PATH)/gcc/$(TARGET_ARCHITECTURE)/$(CROSS_GCC_VER)/include
 
 ifeq (,$(KFLAGS))
-KFLAGS := -D__LINUX_ARM_ARCH__=7 -D__KERNEL__ -nostdinc  -isystem $(KFLAG_INCLD) -I$(LINUX_INCLUDE) -include $(LINUX_INCLUDE)/generated/autoconf.h -I$(KERNDIR)/arch/arm/include -I$(KERNDIR)/arch/arm/include/generated -I$(KERNDIR)/arch/arm/mach-iproc/include -Wall -Wstrict-prototypes -Wno-trigraphs -Os -fno-strict-aliasing -fno-common -marm -mabi=aapcs-linux -fno-pic -pipe -msoft-float -ffreestanding -march=armv7-a -mfloat-abi=softfp -fomit-frame-pointer -g -fno-stack-protector -Wdeclaration-after-statement -Wno-pointer-sign -mlong-calls
+KFLAGS := -D__LINUX_ARM_ARCH__=7 -D__KERNEL__ -nostdinc  -isystem $(KFLAG_INCLD) -I$(LINUX_INCLUDE) -include $(LINUX_INCLUDE)/generated/autoconf.h -I$(KERNDIR)/arch/arm/include -I$(KERNDIR)/arch/arm/include/generated -I$(KERNDIR)/arch/arm/mach-iproc/include -Wall -Wstrict-prototypes -Wno-trigraphs -Os -fno-strict-aliasing -fno-common -marm -mabi=aapcs-linux -fno-pic -pipe -msoft-float -ffreestanding -march=armv7-a -mfloat-abi=softfp -fomit-frame-pointer -g -fno-stack-protector -Wno-frame-address -Wno-address-of-packed-member -Wno-pointer-sign -mlong-calls
 KFLAGS += -I$(LINUX_INCLUDE)/uapi -I$(LINUX_INCLUDE)/generated/uapi -I$(KERNDIR)/arch/arm/include/uapi -I$(KERNDIR)/arch/arm/include/generated/uapi
 
 ifeq "$(shell expr $(CROSS_GCC_VER_MAJOR) \== 10)" "1"

--- a/make/Makefile.linux-iproc-3_14
+++ b/make/Makefile.linux-iproc-3_14
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-iproc-3_6,v 1.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-iproc-4_4
+++ b/make/Makefile.linux-iproc-4_4
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-iproc Exp $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-iproc_64
+++ b/make/Makefile.linux-iproc_64
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-iproc Exp $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.
@@ -34,9 +34,8 @@ BUILD_PLATFORM=ARM_LINUX
 endif
 
 # Upgrade TCL version from default 8.3 to 8.4
-ifneq ($(ESW_CHIPS)$(LTSW_CHIPS),)
+# Because the incompatible-pointer-types warnings will be treated as errors in new toolchain.
 export TCL840 := 1
-endif
 
 # TOOLCHAIN_BASE_DIR    Toolchain base directory for iPROC-CMICd devices
 # TARGET_ARCHITECTURE   Compiler for target architecture
@@ -44,12 +43,12 @@ endif
 ifeq (BE,$(ENDIAN_MODE))
 #We've never actually built a 64 BE executable.  Just here for any future
 #customer requirements.
-TOOLCHAIN_BASE_DIR ?= /projects/ntsw-tools/linux/iproc_ldks/xldk63-be/XLDK64
+TOOLCHAIN_BASE_DIR ?= /projects/ntsw-tools/linux/iproc_ldks/xldk64-be/XLDK64
 KERN_BASE_DIR ?= $(TOOLCHAIN_BASE_DIR)
 TARGET_ARCHITECTURE ?= aarch64_be-broadcom-linux-uclibc
 KERNDIR ?= $(KERN_BASE_DIR)/kernel/linux
 else
-TOOLCHAIN_BASE_DIR ?= /projects/ntsw-tools/linux/iproc_ldks/xldk63/XLDK64
+TOOLCHAIN_BASE_DIR ?= /projects/ntsw-tools/linux/iproc_ldks/xldk64/XLDK64
 KERN_BASE_DIR ?= $(TOOLCHAIN_BASE_DIR)
 TARGET_ARCHITECTURE ?= aarch64-broadcom-linux-uclibc
 KERNDIR ?= $(KERN_BASE_DIR)/kernel/linux
@@ -88,6 +87,7 @@ endif
 ifeq ($(LOCALDIR),src/soc/phy/fcmap/src)
 OPT_CFLAGS += -Wno-address-of-packed-member
 endif
+
 CFGFLAGS += -DPTRS_ARE_64BITS -DLONGS_ARE_64BITS
 CFGFLAGS += -DPHYS_ADDRS_ARE_64BITS
 CFLAGS += -fno-aggressive-loop-optimizations -fno-strict-overflow
@@ -99,7 +99,15 @@ ifeq "$(shell expr $(CROSS_GCC_VER_MAJOR) \>= 12)" "1"
 	CFLAGS += -flarge-source-files
 endif
 
-CFGFLAGS += -D$(ENDIAN) -DIPROC_CMICD
+CFGFLAGS += -D$(ENDIAN)
+# IPROC_CMICD enables iproc platform driver which requires iproc_platform_* symbols
+# from the Broadcom BSP kernel. Omit when building against generic kernel (e.g. Debian).
+# Set BUILD_WITH_IPROC_BSP=1 only when building with a BSP kernel that provides those symbols.
+BUILD_WITH_IPROC_BSP ?= 0
+ifeq ($(BUILD_WITH_IPROC_BSP),1)
+CFGFLAGS += -DIPROC_CMICD
+endif
+
 CFGFLAGS += -DBCM_PLATFORM_STRING=\"IPROC_CMICD\"
 #CFGFLAGS += -DSAL_BDE_DMA_MEM_DEFAULT=16
 
@@ -121,10 +129,10 @@ basename_flags = -D"KBUILD_BASENAME=KBUILD_STR($(call name-fix,$(basetarget)))"
 modname_flags  = $(if $(filter 1,$(words $(modname))),\
                  -D"KBUILD_MODNAME=KBUILD_STR($(call name-fix,$(modname)))")
 
-KFLAG_INCLD ?= $(LD_LIBRARY_PATH)/../gcc/$(TARGET_ARCHITECTURE)/$(CROSS_GCC_VER)/include
+KFLAG_INCLD ?= $(LD_LIBRARY_PATH)/gcc/$(TARGET_ARCHITECTURE)/$(CROSS_GCC_VER)/include
 
 ifeq (,$(KFLAGS))
-KFLAGS := -D__LINUX_ARM_ARCH__=8 -D__KERNEL__ -DPTRS_ARE_64BITS -DLONGS_ARE_64BITS -nostdinc -isystem $(KFLAG_INCLD) -I$(LINUX_INCLUDE) -include $(LINUX_INCLUDE)/generated/autoconf.h -I$(KERNDIR)/arch/arm64/include -I$(KERNDIR)/arch/arm64/include/generated -I$(KERNDIR)/arch/arm64/include/generated/uapi -I$(KERNDIR)/arch/arm64/include/generated/asm -I$(KERNDIR)/include/uapi -I$(KERNDIR)/include/generated/uapi -I$(KERNDIR)/arch/arm64/include/uapi  -Wall -Wstrict-prototypes -Wno-trigraphs -O2 -fno-strict-aliasing -fno-common -fno-pic -pipe -ffreestanding -fomit-frame-pointer -g -fno-stack-protector -Wdeclaration-after-statement -Wno-pointer-sign -mcmodel=large
+KFLAGS := -D__LINUX_ARM_ARCH__=8 -D__KERNEL__ -DPTRS_ARE_64BITS -DLONGS_ARE_64BITS -nostdinc -isystem $(KFLAG_INCLD) -I$(LINUX_INCLUDE) -include $(LINUX_INCLUDE)/generated/autoconf.h -I$(KERNDIR)/arch/arm64/include -I$(KERNDIR)/arch/arm64/include/generated -I$(KERNDIR)/arch/arm64/include/generated/uapi -I$(KERNDIR)/arch/arm64/include/generated/asm -I$(KERNDIR)/include/uapi -I$(KERNDIR)/include/generated/uapi -I$(KERNDIR)/arch/arm64/include/uapi  -Wall -Wstrict-prototypes -Wno-trigraphs -O2 -fno-strict-aliasing -fno-common -fno-pic -pipe -ffreestanding -fomit-frame-pointer -g -fno-stack-protector -Wno-frame-address -Wno-address-of-packed-member -Wno-pointer-sign -mcmodel=large
 endif
 
 ifneq ($(targetplat),user)

--- a/make/Makefile.linux-kernel
+++ b/make/Makefile.linux-kernel
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-kernel,v 1.27 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-kernel-2_6
+++ b/make/Makefile.linux-kernel-2_6
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-kernel-2_6,v 1.40 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-kernel-3_6
+++ b/make/Makefile.linux-kernel-3_6
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-kernel-3_6,v 1.2 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-kernel-4_18
+++ b/make/Makefile.linux-kernel-4_18
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-kernel-4_18,v 1.00 $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-kernel-4_4
+++ b/make/Makefile.linux-kernel-4_4
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-kernel-2_6,v 1.40 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-kmodule
+++ b/make/Makefile.linux-kmodule
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-kmodule-3_6,v 1.2 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-slk
+++ b/make/Makefile.linux-slk
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-slk Exp $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-x86-5_10
+++ b/make/Makefile.linux-x86-5_10
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-gts,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-x86-64-fc28
+++ b/make/Makefile.linux-x86-64-fc28
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-gts,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-x86-common-2_6
+++ b/make/Makefile.linux-x86-common-2_6
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-x86-common-2_6,v 1.13 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-x86-generic-common-2_6
+++ b/make/Makefile.linux-x86-generic-common-2_6
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-x86-generic-common-2_6,v 1.2 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/make/Makefile.linux-x86-smp_generic_64-2_6
+++ b/make/Makefile.linux-x86-smp_generic_64-2_6
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-x86-smp_generic_64-2_6,v 1.5 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.
@@ -32,10 +32,22 @@ CFGFLAGS += -DPTRS_ARE_64BITS
 CFGFLAGS += -DPHYS_ADDRS_ARE_64BITS
 CFGFLAGS += -DSAL_SPL_LOCK_ON_IRQ
 
+ifneq ($(ESW_CHIPS)$(LTSW_CHIPS),)
+# Glibc 2.27 or later version doesn't support SVID libm error handling.
+# Building tcl 8.3.3 with the new toolchain will occur errors.
+export TCL840  := 1
+endif
+
 include ${SDK}/make/Makefile.linux-x86-generic-common-2_6
+
+GCC_VER_MAJOR := $(shell $(CC) -dumpversion 2>/dev/null | cut -f1 -d.)
 
 ifeq (,$(KFLAGS))
 KFLAGS := -nostdinc -isystem $(SYSINC) -I$(KERNDIR)/include -I$(KERNDIR)/arch/x86/include -include $(AUTOCONF) -D__KERNEL__ -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs -fno-strict-aliasing -fno-common -Werror-implicit-function-declaration -Wno-format-security -fno-delete-null-pointer-checks -Os -m64 -mtune=generic -mno-red-zone -fno-pie -mcmodel=kernel -DCONFIG_AS_CFI=1 -DCONFIG_AS_CFI_SIGNAL_FRAME=1 -pipe -Wno-sign-compare -fno-asynchronous-unwind-tables -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -fno-stack-protector -fomit-frame-pointer -g -Wdeclaration-after-statement -Wno-pointer-sign
+ifeq "$(shell expr $(GCC_VER_MAJOR) \>= 12)" "1"
+KFLAGS += -std=gnu11 -Wno-error=attributes -Wno-error=declaration-after-statement
+KFLAGS += -Wno-attributes -Wno-declaration-after-statement
+endif
 ifneq (1,$(USE_CLANG))
 KFLAGS += -funit-at-a-time -maccumulate-outgoing-args
 endif
@@ -44,6 +56,13 @@ endif
 LINUX_UAPI = $(LINUX_INCLUDE)/uapi
 ifneq (,$(shell ls $(LINUX_UAPI) 2>/dev/null))
 KFLAGS += -I$(LINUX_INCLUDE)/uapi -I$(LINUX_INCLUDE)/generated/uapi -I$(KERNDIR)/arch/x86/include/generated -I$(KERNDIR)/arch/x86/include/uapi -I$(KERNDIR)/arch/x86/include/generated/uapi
+endif
+
+ifeq "$(shell expr $(GCC_VER_MAJOR) \>= 12)" "1"
+KFLAGS += -mfunction-return=thunk-extern -fpatchable-function-entry=16,16
+KFLAGS += -mindirect-branch=thunk-extern -mindirect-branch-cs-prefix
+# IBT: emit ENDBR so objtool "relocation to !ENDBR" warnings are resolved
+KFLAGS += -fcf-protection=branch
 endif
 
 ifdef LTSW_CHIPS

--- a/make/Makefile.linux-xlr
+++ b/make/Makefile.linux-xlr
@@ -1,6 +1,6 @@
 # $Id: Makefile.linux-xlr-4_19,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/bde/linux/include/linux-bde.h
+++ b/systems/bde/linux/include/linux-bde.h
@@ -2,7 +2,7 @@
  *
  * $Id: linux-bde.h,v 1.24 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -270,6 +270,7 @@ extern linux_bde_device_bitmap_t* lkbde_get_inst_devs(uint32 inst_id);
 extern int lkbde_irq_mask_set(int d, uint32 addr, uint32 mask, uint32 fmask);
 extern int lkbde_irq_mask_get(int d, uint32 *mask, uint32 *fmask);
 extern int lkbde_irq_status_get(int d, uint32_t addr, uint32 *status);
+extern int lkbde_irq_clear_set(int d, uint32 addr);
 
 #ifdef BCM_SAND_SUPPORT
 extern int lkbde_cpu_write(int d, uint32 addr, uint32 *buf);
@@ -298,6 +299,10 @@ extern void _update_apis_for_sram_dma();
 #endif
 extern void lkbde_get_sram_dma_info(unsigned d, uint32 *sram_start, uint32 *sram_size);
 #endif /* INCLUDE_SRAM_DMA */
+
+#ifdef INCLUDE_CPU_I2C
+extern void lkbde_get_i2c_info(int d, uint32 *i2c_bus, uint32 *i2c_dev, uint32 *use_default);
+#endif
 /*
  * This flag must be OR'ed onto the device number when calling
  * interrupt_connect/disconnect and irq_mask_set functions from

--- a/systems/bde/linux/include/linux_dma.h
+++ b/systems/bde/linux/include/linux_dma.h
@@ -2,7 +2,7 @@
  *
  * $Id: linux_dma.h,v 1.24 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/linux/include/mpool.h
+++ b/systems/bde/linux/include/mpool.h
@@ -1,7 +1,7 @@
 /*
  * $Id: mpool.h,v 1.2 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/linux/kernel/Makefile
+++ b/systems/bde/linux/kernel/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.18 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/bde/linux/kernel/linux-kernel-bde.c
+++ b/systems/bde/linux/kernel/linux-kernel-bde.c
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -204,6 +204,13 @@ MODULE_PARM_DESC(spifreq,
 #endif
 
 
+#define I2C_NO_ID 0x7fffffff
+
+/* module param for adding dummy switch devices */
+static char *dummy_devices;
+LKM_MOD_PARAM(dummy_devices, "s", charp, 0);
+MODULE_PARM_DESC(dummy_devices,
+"List of dummy switch devices to be added. Input format (devid=%x revid=%x type=%x unique_id=%x [i2c_bus=%x i2c_device=%x]");
 
 /* Periodic timer to prevent stuck interrupt */
 static int isrtickms = 1000;
@@ -415,6 +422,10 @@ typedef struct bde_ctrl_s {
     uint32 dev_sram_dma_start;    /* start address of device SRAM used for DMA */
     uint32 dev_sram_dma_size;     /* size in bytes of device SRAM used for DMA */
 #endif /* INCLUDE_SRAM_DMA */
+#ifdef INCLUDE_CPU_I2C
+    uint32  i2c_bus;
+    uint32  i2c_dev;
+#endif /* INCLUDE_CPU_I2C */
 } bde_ctrl_t;
 
 static bde_ctrl_t _devices[LINUX_BDE_MAX_DEVICES];
@@ -433,6 +444,7 @@ static int _ether_ndevices = 0;
 static int _cpu_ndevices = 0;
 
 #define VALID_DEVICE(_n) ((_n >= 0) && (_n < _ndevices))
+#define REMOVED_DEVICE(_n) (_devices[_n].dev_state == BDE_DEV_STATE_REMOVED)
 
 #if defined(IPROC_CMICD) && defined(CONFIG_OF)
 #define ICFG_CHIP_ID_REG      0x10236000
@@ -1280,20 +1292,6 @@ static const struct pci_device_id _id_table[] = {
     { BROADCOM_VENDOR_ID, BCM56801_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
     { BROADCOM_VENDOR_ID, BCM56802_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
     { BROADCOM_VENDOR_ID, BCM56803_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56630_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56634_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56636_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56638_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56639_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56538_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56520_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56521_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56522_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56524_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56526_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56534_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56331_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
-    { BROADCOM_VENDOR_ID, BCM56333_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
     { BROADCOM_VENDOR_ID, BCM56534_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
     { BROADCOM_VENDOR_ID, BCM56334_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
     { BROADCOM_VENDOR_ID, BCM56320_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
@@ -1806,6 +1804,19 @@ static const struct pci_device_id _id_table[] = {
     { BROADCOM_VENDOR_ID, Q4D_DEVICE_ID + 9, PCI_ANY_ID, PCI_ANY_ID },
 #endif
 
+#ifdef BCM_Q4DL_SUPPORT
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 1, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 2, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 3, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 4, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 5, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 6, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 7, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 8, PCI_ANY_ID, PCI_ANY_ID },
+    { BROADCOM_VENDOR_ID, Q4DL_DEVICE_ID + 9, PCI_ANY_ID, PCI_ANY_ID },
+#endif
+
 
 #ifdef BCM_J4L_SUPPORT
     { BROADCOM_VENDOR_ID, J4L_DEVICE_ID, PCI_ANY_ID, PCI_ANY_ID },
@@ -1819,6 +1830,8 @@ static const struct pci_device_id _id_table[] = {
     { BROADCOM_VENDOR_ID, J4L_DEVICE_ID + 8, PCI_ANY_ID, PCI_ANY_ID },
     { BROADCOM_VENDOR_ID, J4L_DEVICE_ID + 9, PCI_ANY_ID, PCI_ANY_ID },
 #endif
+
+
 
 
 #endif
@@ -2693,6 +2706,10 @@ _pci_probe(struct pci_dev *dev, const struct pci_device_id *ent)
             ctrl->dev_type |= BDE_SWITCH_DEV_TYPE;
             ctrl->domain_no = pci_domain_nr(dev->bus);
             ctrl->bus_no = dev->bus->number;
+#ifdef INCLUDE_CPU_I2C
+            ctrl->i2c_bus = I2C_NO_ID;
+            ctrl->i2c_dev = I2C_NO_ID;
+#endif
             ctrl->dev_state = BDE_DEV_STATE_NORMAL;
             add_dev = 1;
         }
@@ -3118,6 +3135,17 @@ _pci_remove(struct pci_dev* dev)
         /* Unused device */
         return;
     }
+
+#ifdef CONFIG_PCI_MSI
+    /* Stop the ISR tick timer BEFORE setting dev_state
+     * This prevents the timer from firing after memory is unmapped */
+    if (ctrl->intr_pending && ctrl->use_msi >= PCI_USE_INT_MSI
+         && ctrl->timer_active) {
+        ctrl->timer_active = 0;
+        del_timer_sync(&ctrl->isr_tick);
+    }
+#endif
+
     ctrl->dev_state = BDE_DEV_STATE_REMOVED;
     if (debug >= 1) {
         gprintk("PCI device %04x:%04x is removed. \n",
@@ -3141,11 +3169,6 @@ _pci_remove(struct pci_dev* dev)
         }
     }
 #ifdef CONFIG_PCI_MSI
-    if (ctrl->intr_pending && ctrl->use_msi >= PCI_USE_INT_MSI && ctrl->timer_active) {
-        ctrl->timer_active = 0;
-        del_timer_sync(&ctrl->isr_tick);
-    }
-
     _msi_disconnect(ctrl);
 #endif
 
@@ -3157,9 +3180,11 @@ _pci_remove(struct pci_dev* dev)
 
     if (ctrl->bde_dev.base_address1) {
         iounmap((void *)ctrl->bde_dev.base_address1);
+        ctrl->bde_dev.base_address1 = 0;
     }
     if (ctrl->bde_dev.base_address) {
         iounmap((void *)ctrl->bde_dev.base_address);
+        ctrl->bde_dev.base_address = 0;
     }
 }
 
@@ -3316,7 +3341,89 @@ probe_plx_local_bus(void)
 
 #endif /* BCM_PLX9656_LOCAL_BUS */
 
+/*
+ * Add a dummy (non-real) switch device used for testing the BDE.
+ * Returns zero on success.
+ */
+static int
+add_dummy_switch_device(uint16 device_id, uint8  revision_id, uint32 dev_type, uint32 unique_id, uint32 i2c_bus, uint32 i2c_device)
+{
+    bde_ctrl_t *ctrl = _devices + _ndevices;
+#ifdef INCLUDE_SRAM_DMA
+    uint32 icfg_rts_straps_addr = 0, iproc_version = 0;
+#endif
 
+    if (_ndevices >= LINUX_BDE_MAX_DEVICES) return -1;
+
+    ctrl->dev_type = dev_type;
+    ctrl->pci_device = NULL; /* No PCI bus */
+    ctrl->bde_dev.base_address = 0;
+    ctrl->iowin[0].addr = 0;
+    ctrl->iowin[0].size = 0;
+    ctrl->bde_dev.device = device_id;
+    ctrl->bde_dev.rev = revision_id;
+    ctrl->bde_dev.dev_unique_id = unique_id;
+#ifdef INCLUDE_CPU_I2C
+    ctrl->i2c_bus = i2c_bus;
+    ctrl->i2c_dev = i2c_device;
+#endif
+
+#ifdef INCLUDE_SRAM_DMA
+    /* Check if the device should use SRAM for DMA, if so configure the SRAM to be used */
+    if (use_sram_for_dma) {
+        switch (device_id & DNXC_DEVID_FAMILY_MASK) {
+            case RAMON2_DEVICE_ID: /* Mark the device as user type if SRAM mode RM2/3 */
+            case RAMON3_DEVICE_ID:
+            case JERICHO3_DEVICE_ID:
+            case J3AI_DEVICE_ID:
+            case Q3D_DEVICE_ID:
+#ifdef BCM_Q3A_SUPPORT
+            case Q3A_DEVICE_ID:
+            case Q3U_DEVICE_ID:
+#endif
+            iproc_version = 20;
+                break;
+
+            case JERICHO4_DEVICE_ID:
+            case Q4_DEVICE_ID:
+            case Q4D_DEVICE_ID:
+            case J4L_DEVICE_ID:
+            iproc_version = 21;
+                break;
+            default:
+                gprintk("Error: device 0x%x does not support SRAMDMA access\n", device_id);
+        }
+
+        if (iproc_version == 20) {
+            icfg_rts_straps_addr = 0x2920034;
+        } else if (iproc_version >= 21) {
+            icfg_rts_straps_addr = 0x2920030;
+        }
+
+        if (icfg_rts_straps_addr) {
+            if ((shbde_iproc_pci_read(&ctrl->shbde, (void *)ctrl->bde_dev.base_address1, icfg_rts_straps_addr) & 2) != 0) {
+                ctrl->dev_sram_dma_start = 0x38100000;
+                ctrl->dev_sram_dma_size = 0x400000; /* 4MB */
+            } else { /* Use free M0SSQ SRAM */
+                ctrl->dev_sram_dma_start = 0x2070000;
+                ctrl->dev_sram_dma_size = 0x10000; /* 64KB */
+            }
+
+            ctrl->dev_type |= BDE_USER_DEV_TYPE; /* Mark as user defined access for BDE handling access to BARs */
+            if (debug >= 4) {
+                gprintk("PCI device 0x%x using SRAM DMA at 0x%x size 0x%x dev_type=0x%x dev=%u\n", device_id,
+                        ctrl->dev_sram_dma_start, ctrl->dev_sram_dma_size, ctrl->dev_type, (unsigned)(ctrl - _devices));
+            }
+        } else {
+            ctrl->dev_sram_dma_start = ctrl->dev_sram_dma_size = 0;
+        }
+    }
+#endif /* INCLUDE_SRAM_DMA */
+
+    _bde_add_device();
+
+    return 0;
+}
 
 
 
@@ -3452,6 +3559,36 @@ _init(void)
         }
     }
 
+
+    /* If argument was provided, add dummy devices according to it */
+    if (dummy_devices) {
+        char  *token;
+        unsigned int devid = 0, revid = 0, devtype = 0, unique_id = 0;
+        unsigned int  i2c_bus = I2C_NO_ID, i2c_device = I2C_NO_ID;
+
+        gprintk("dummy device to add: %s\n", dummy_devices);
+        token = strtok(dummy_devices, ";");
+        while (token) {
+            _parse_eb_args(token, "devid=%x,revid=%x,type=%x,unique_id=%x,i2c_bus=%x,i2c_device=%x",
+                           &devid, &revid, &devtype, &unique_id, &i2c_bus, &i2c_device);
+            if (!devid || !devtype || !unique_id) {
+                gprintk("Invalid dummy_devices format or zero values: devid=0x%x revid=0x%x type=0x%x unique_id=0x%x [i2c_bus=0x%x i2c_device=0x%x]\n",
+                        devid, revid, devtype, unique_id, i2c_bus, i2c_device);
+                break;
+            }
+
+            /* Add dummy devices based on kernel module argument */
+            if (add_dummy_switch_device(devid, revid, devtype, unique_id, i2c_bus, i2c_device)) {
+                gprintk("failed adding dummy device: devid=0x%x revid=0x%x type=0x%x unique_id=0x%x [i2c_bus=0x%x i2c_device=0x%x]\n",
+                            devid, revid, devtype, unique_id, i2c_bus, i2c_device);
+            } else if (debug >= 1) {
+                gprintk("added dummy device: devid=0x%x revid=0x%x type=0x%x unique_id=0x%x [i2c_bus=0x%x i2c_device=0x%x]\n",
+                            devid, revid, devtype, unique_id, i2c_bus, i2c_device);
+            }
+
+            token = strtok(NULL, ";");
+        }
+    }
 
     for (i = 0; i < LINUX_BDE_MAX_DEVICES; ++i) {
         _devices[i].inst_id = BDE_DEV_INST_ID_INVALID;
@@ -3609,6 +3746,24 @@ _pprint(struct seq_file *m)
                     ctrl->iLine);
         } else if (ctrl->dev_type & BDE_EB_DEV_TYPE) {
             pprintf(m, "EB Bus Device 0x%x:0x%x\n",
+                    ctrl->bde_dev.device,
+                    ctrl->bde_dev.rev);
+        } else if (ctrl->dev_type & (BDE_USER_DEV_TYPE | BDE_I2C_DEV_TYPE)) {
+            pprintf(m, "Dummy Device using I2C 0x%x:0x%x\n",
+                    ctrl->bde_dev.device,
+                    ctrl->bde_dev.rev);
+#ifdef INCLUDE_CPU_I2C
+            pprintf(m, "\t\ti2c_bus=0x%x i2c_dev=0x%x\n",
+                    ctrl->i2c_bus,
+                    ctrl->i2c_dev);
+#endif
+#ifdef INCLUDE_SRAM_DMA
+            pprintf(m, "\t\tdev_sram_dma_start=0x%x dev_sram_dma_size=0x%x\n",
+                    ctrl->dev_sram_dma_start,
+                    ctrl->dev_sram_dma_size);
+#endif
+        } else if (ctrl->dev_type & BDE_USER_DEV_TYPE) {
+            pprintf(m, "User defined Device 0x%x:0x%x\n",
                     ctrl->bde_dev.device,
                     ctrl->bde_dev.rev);
         }
@@ -3778,9 +3933,18 @@ _pci_conf_read(int d, uint32 addr)
         return 0xFFFFFFFF;
     }
 
+    if (REMOVED_DEVICE(d)) {
+        gprintk("_pci_conf_read: Device was removed %d\n", d);
+        return 0xFFFFFFFF;
+    }
+
     if (!(_devices[d].dev_type & BDE_PCI_DEV_TYPE)) {
         gprintk("_pci_conf_read: Not PCI device %d, type %x\n",
                 d, _devices[d].dev_type);
+        return 0xFFFFFFFF;
+    }
+
+    if (_devices[d].pci_device == NULL) {
         return 0xFFFFFFFF;
     }
 
@@ -3800,9 +3964,18 @@ _pci_conf_write(int d, uint32 addr, uint32 data)
         return -1;
     }
 
+    if (REMOVED_DEVICE(d)) {
+        gprintk("_pci_conf_write: Device was removed %d\n", d);
+        return -1;
+    }
+
     if (!(_devices[d].dev_type & BDE_PCI_DEV_TYPE)) {
         gprintk("_pci_conf_write: Not PCI device %d, type %x\n",
                 d, _devices[d].dev_type);
+        return -1;
+    }
+
+    if (_devices[d].pci_device == NULL) {
         return -1;
     }
 
@@ -3846,7 +4019,7 @@ _read(int d, uint32_t addr)
     volatile uint16  msb, lsb;
     uint32  sl_addr, data;
 
-    if (!VALID_DEVICE(d)) {
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) {
         return -1;
     }
 
@@ -3882,7 +4055,7 @@ _write(int d, uint32_t addr, uint32_t data)
     unsigned long flags;
     uint32  sl_addr;
 
-    if (!VALID_DEVICE(d)) {
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) {
         return -1;
     }
 
@@ -3922,7 +4095,7 @@ static uint64
 _read64(int d, uint32_t addr)
 {
     uint64_t  data;
-    if (!VALID_DEVICE(d)) {
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) {
         data =  (uint64_t)-1;
         return *(uint64 *)&data;
     }
@@ -3942,7 +4115,8 @@ _read64(int d, uint32_t addr)
 static void
 _write64(int d, uint32_t addr, uint64 data)
 {
-    if (!VALID_DEVICE(d) || !(BDE_DEV_MEM_MAPPED(_devices[d].dev_type))) {
+    if (!VALID_DEVICE(d) || !(BDE_DEV_MEM_MAPPED(_devices[d].dev_type))
+         || REMOVED_DEVICE(d)) {
         return;
     }
 
@@ -4399,7 +4573,7 @@ _iproc_ihost_write(int d, uint32_t addr, uint32_t data)
 static uint32_t
 _iproc_read(int d, uint32_t addr)
 {
-    if (!VALID_DEVICE(d)) {
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) {
         return -1;
     }
 
@@ -4422,7 +4596,7 @@ _iproc_read(int d, uint32_t addr)
 static int
 _iproc_write(int d, uint32_t addr, uint32_t data)
 {
-    if (!VALID_DEVICE(d)) {
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) {
         return -1;
     }
 
@@ -4534,11 +4708,15 @@ lkbde_cpu_pci_register(int d)
     bde_ctrl_t* ctrl;
     uint16  cmd = 0;
 
-    if (!VALID_DEVICE(d)) {
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) {
         return -1;
     }
 
     ctrl = &_devices[d];
+
+    if (ctrl->pci_device == NULL) {
+        return -1;
+    }
 
     /* enable device */
     if (pci_enable_device(ctrl->pci_device)) {
@@ -4677,6 +4855,9 @@ lkbde_cpu_pci_register(int d)
 #ifdef BCM_Q4D_SUPPORT
       case Q4D_DEVICE_ID:
 #endif
+#ifdef BCM_Q4DL_SUPPORT
+      case Q4DL_DEVICE_ID:
+#endif
 #ifdef BCM_J4L_SUPPORT
       case J4L_DEVICE_ID:
 #endif
@@ -4734,7 +4915,7 @@ lkbde_mem_write(int d, uint32 addr, uint32 *buf)
     bde_ctrl_t* ctrl;
     void *full_addr;
 
-    if (!VALID_DEVICE(d)) return -1;
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) return -1;
     ctrl = &_devices[d];
 
     full_addr   = (void *)ctrl->bde_dev.base_address + addr;
@@ -4749,7 +4930,7 @@ lkbde_mem_read(int d, uint32 addr, uint32 *buf)
     bde_ctrl_t* ctrl;
     void *full_addr;
 
-    if (!VALID_DEVICE(d)) return -1;
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) return -1;
     ctrl = &_devices[d];
 
     full_addr   = (void *)ctrl->bde_dev.base_address + addr;
@@ -4964,13 +5145,16 @@ lkbde_get_dev_resource(int d, int rsrc, uint32_t *phys_lo,
 void *
 lkbde_get_dma_dev(int d)
 {
-    if (!VALID_DEVICE(d)) {
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) {
         return NULL;
     }
 
 #ifdef LINUX_BDE_DMA_DEVICE_SUPPORT
     return (void *)_devices[d].dma_dev;
 #else
+    if (_devices[d].pci_device == NULL) {
+        return NULL;
+    }
     return (void *)_devices[d].pci_device;
 #endif
 }
@@ -4978,7 +5162,11 @@ lkbde_get_dma_dev(int d)
 void *
 lkbde_get_hw_dev(int d)
 {
-    if (!VALID_DEVICE(d)) {
+    if (!VALID_DEVICE(d) || REMOVED_DEVICE(d)) {
+        return NULL;
+    }
+
+    if (_devices[d].pci_device == NULL) {
         return NULL;
     }
 
@@ -5113,6 +5301,36 @@ lkbde_irq_mask_set(int d, uint32_t addr, uint32_t mask, uint32_t fmask)
         _iproc_write(d, addr, ctrl->imask | ctrl->imask2);
     } else {
         _write(d, addr, ctrl->imask | ctrl->imask2);
+    }
+
+    spin_unlock_irqrestore(&ctrl->lock, flags);
+
+    return 0;
+}
+
+int
+lkbde_irq_clear_set(int d, uint32_t addr)
+{
+    bde_ctrl_t *ctrl;
+    int iproc_reg;
+    unsigned long flags;
+
+    iproc_reg = d & LKBDE_IPROC_REG;
+    d &= ~(LKBDE_ISR2_DEV | LKBDE_IPROC_REG);
+
+    if (!VALID_DEVICE(d)) {
+        return -1;
+    }
+
+    ctrl = _devices + d;
+
+    /* Lock is required to synchronize access from user space */
+    spin_lock_irqsave(&ctrl->lock, flags);
+
+    if (iproc_reg) {
+        _iproc_write(d, addr, ~(ctrl->imask | ctrl->imask2));
+    } else {
+        _write(d, addr, ~(ctrl->imask | ctrl->imask2));
     }
 
     spin_unlock_irqrestore(&ctrl->lock, flags);
@@ -5328,6 +5546,25 @@ lkbde_get_sram_dma_info(unsigned d, uint32 *sram_start, uint32 *sram_size)
 }
 #endif /* INCLUDE_SRAM_DMA */
 
+#ifdef INCLUDE_CPU_I2C
+/* Return the i2c bus and i2c device if they were specified in the kernel arguments */
+void
+lkbde_get_i2c_info(int d, uint32 *i2c_bus, uint32 *i2c_dev, uint32 *use_default)
+{
+
+    if (d < _ndevices && _devices[d].i2c_bus != I2C_NO_ID && _devices[d].i2c_dev != I2C_NO_ID) { /* This is an I2C info was specified */
+        *i2c_bus = _devices[d].i2c_bus;
+        *i2c_dev = _devices[d].i2c_dev;
+        *use_default = 0;
+    } else {
+        *use_default = 1;
+    }
+}
+
+LKM_EXPORT_SYM(lkbde_get_i2c_info);
+
+#endif /* INCLUDE_CPU_I2C */
+
 /*
  * Export functions
  */
@@ -5341,6 +5578,7 @@ LKM_EXPORT_SYM(lkbde_get_dma_dev);
 LKM_EXPORT_SYM(lkbde_irq_mask_set);
 LKM_EXPORT_SYM(lkbde_irq_mask_get);
 LKM_EXPORT_SYM(lkbde_irq_status_get);
+LKM_EXPORT_SYM(lkbde_irq_clear_set);
 LKM_EXPORT_SYM(lkbde_get_dev_phys_hi);
 LKM_EXPORT_SYM(lkbde_dev_state_set);
 LKM_EXPORT_SYM(lkbde_dev_state_get);

--- a/systems/bde/linux/kernel/linux_dma.c
+++ b/systems/bde/linux/kernel/linux_dma.c
@@ -1,7 +1,7 @@
 /*
  * $Id: linux_dma.c,v 1.414 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -92,10 +92,19 @@
 #define ALLOC_TYPE_API 1 /* use one allocation */
 #define ALLOC_TYPE_HIMEM 2 /* use high memory */
 
+/* MAX_ORDER changed meaning in 6.4 and was removed in 6.8 */
+#ifndef MAX_PAGE_ORDER
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0))
+#define MAX_PAGE_ORDER MAX_ORDER
+#else
+#define MAX_PAGE_ORDER (MAX_ORDER - 1)
+#endif
+#endif
+
 #if _SIMPLE_MEMORY_ALLOCATION_
 #include <linux/dma-mapping.h>
 #ifndef CONFIG_CMA
-#define DMA_MAX_ALLOC_SIZE (1 << (MAX_PAGE_ORDER - 1 + PAGE_SHIFT)) /* Maximum size the kernel can allocate in one allocation */
+#define DMA_MAX_ALLOC_SIZE (1 << (MAX_PAGE_ORDER  + PAGE_SHIFT)) /* Maximum size the kernel can allocate in one allocation */
 #endif /* !CONFIG_CMA */
 #endif /* _SIMPLE_MEMORY_ALLOCATION_ */
 
@@ -140,7 +149,7 @@
 #endif
 
 #ifndef KMALLOC_MAX_SIZE
-#define KMALLOC_MAX_SIZE (1UL << (MAX_PAGE_ORDER - 1 + PAGE_SHIFT))
+#define KMALLOC_MAX_SIZE (1UL << (MAX_PAGE_ORDER + PAGE_SHIFT))
 #endif
 
 /* Compatibility */

--- a/systems/bde/linux/kernel/linux_shbde.c
+++ b/systems/bde/linux/kernel/linux_shbde.c
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/linux/kernel/linux_shbde.h
+++ b/systems/bde/linux/kernel/linux_shbde.h
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/linux/shared/mpool.c
+++ b/systems/bde/linux/shared/mpool.c
@@ -1,7 +1,7 @@
 /*
  * $Id: mpool.c,v 1.18 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/linux/user/kernel/Makefile
+++ b/systems/bde/linux/user/kernel/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.13 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/bde/linux/user/kernel/linux-user-bde.c
+++ b/systems/bde/linux/user/kernel/linux-user-bde.c
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -519,8 +519,16 @@ _cmicx_interrupt_prepare(bde_ctrl_t *ctrl)
     int d, ind, ret = 0;
     uint32 stat, iena, mask, fmask;
     uint32 intrs = 0;
+    uint32 dev_state = BDE_DEV_STATE_NORMAL;
 
     d = (((uint8 *)ctrl - (uint8 *)_devices) / sizeof (bde_ctrl_t));
+
+    (void)lkbde_dev_state_get(d, &dev_state);
+    if (dev_state == BDE_DEV_STATE_REMOVED) {
+        /* Return directly if PCIe device was removed */
+        return -1;
+    }
+
 
 #ifdef BDE_EDK_SUPPORT
     /* Check for interrupts meant for EDK and return without wasting time */
@@ -629,10 +637,17 @@ _cmicx_interrupt_pending(void *data)
     int d, ind;
     uint32 stat, iena;
     bde_ctrl_t *ctrl = (bde_ctrl_t *)data;
+    uint32 dev_state = BDE_DEV_STATE_NORMAL;
 
     if (ctrl->dev_type & BDE_PCI_DEV_TYPE) {
 
         d = (((uint8 *)ctrl - (uint8 *)_devices) / sizeof (bde_ctrl_t));
+
+        (void)lkbde_dev_state_get(d, &dev_state);
+        if (dev_state == BDE_DEV_STATE_REMOVED) {
+            /* Not handling interrupts if PCIe device was removed */
+            return 0;
+        }
 
         for (ind = 0; ind < ctrl->intr_regs.intc_intr_nof_regs; ind++) {
             IPROC_READ(d, ctrl->intr_regs.intc_intr_status_base + 4 * ind, stat);
@@ -1411,10 +1426,13 @@ _devices_init(int d)
 #ifdef BCM_Q4D_SUPPORT
           case Q4D_DEVICE_ID:
 #endif
+#ifdef BCM_Q4DL_SUPPORT
+          case Q4DL_DEVICE_ID:
+#endif
 #ifdef BCM_J4L_SUPPORT
           case J4L_DEVICE_ID:
 #endif
-#endif
+#endif /* BCM_DNX3_SUPPORT */
 #ifdef BCM_DNXF3_SUPPORT
           case  RAMON2_DEVICE_ID:
           case  RAMON3_DEVICE_ID:
@@ -2205,6 +2223,13 @@ _ioctl(unsigned int cmd, unsigned long arg)
         else if (_devices[io.dev].isr == _cmicx_gen2_interrupt)
         {
             io.rc = lkbde_irq_mask_set(io.dev | LKBDE_IPROC_REG, io.d0, io.d1, 0);
+            /* Set clear_enable based on irq mask */
+            if (io.rc == LUBDE_SUCCESS)
+            {
+                bde_ctrl_t *ctrl;
+                ctrl = &_devices[io.dev];
+                io.rc = lkbde_irq_clear_set(io.dev | LKBDE_IPROC_REG,  ctrl->intr_regs.intc_intr_clear_enable_base + (io.d0 - ctrl->intr_regs.intc_intr_set_enable_base));
+            }
         }
 #endif
         else {
@@ -2333,6 +2358,18 @@ _ioctl(unsigned int cmd, unsigned long arg)
             user_bde->write64(io.dev, io.d0, val);
         }
         break;
+    case LUBDE_GET_I2C_INFO:
+        if (!VALID_DEVICE(io.dev)) {
+            return -EINVAL;
+        }
+#ifdef INCLUDE_CPU_I2C
+        lkbde_get_i2c_info(io.dev, &io.dx.dw[0], &io.dx.dw[1], &io.dx.dw[2]);
+        break;
+#else
+        gprintk("Error: The build does not support the LUBDE_GET_I2C_INFO ioctl (%08x)\n", cmd);
+        io.rc = LUBDE_FAIL;
+        break;
+#endif
 
     default:
         gprintk("Error: Invalid ioctl (%08x)\n", cmd);

--- a/systems/bde/linux/user/kernel/linux-user-bde.h
+++ b/systems/bde/linux/user/kernel/linux-user-bde.h
@@ -1,7 +1,7 @@
 /*
  * $Id: linux-user-bde.h,v 1.23 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -106,6 +106,7 @@ typedef struct  {
 #define LUBDE_BAR2_WRITE32              _IO(LUBDE_MAGIC, 40)
 #define LUBDE_BAR2_READ64               _IO(LUBDE_MAGIC, 41)
 #define LUBDE_BAR2_WRITE64              _IO(LUBDE_MAGIC, 42)
+#define LUBDE_GET_I2C_INFO              _IO(LUBDE_MAGIC, 43)
 
 
 #define LUBDE_SEM_OP_CREATE       1

--- a/systems/bde/shared/include/shbde.h
+++ b/systems/bde/shared/include/shbde.h
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/shared/include/shbde_iproc.h
+++ b/systems/bde/shared/include/shbde_iproc.h
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/shared/include/shbde_mdio.h
+++ b/systems/bde/shared/include/shbde_mdio.h
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/shared/include/shbde_pci.h
+++ b/systems/bde/shared/include/shbde_pci.h
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/shared/shbde_iproc.c
+++ b/systems/bde/shared/shbde_iproc.c
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/shared/shbde_mdio.c
+++ b/systems/bde/shared/shbde_mdio.c
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/bde/shared/shbde_pci.c
+++ b/systems/bde/shared/shbde_pci.c
@@ -1,7 +1,7 @@
 /*
  * $Id: $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/Makefile
+++ b/systems/linux/kernel/modules/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.10 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/Makefile
+++ b/systems/linux/kernel/modules/bcm-genl/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.3 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl-dev.c
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl-dev.c
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl-dev.h
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl-dev.h
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl-netif.c
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl-netif.c
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl-netif.h
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl-netif.h
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl-packet.c
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl-packet.c
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl-packet.h
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl-packet.h
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl-psample.c
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl-psample.c
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -803,7 +803,7 @@ static ssize_t
 psample_proc_debug_write(struct file *file, const char *buf,
                          size_t count, loff_t *loff)
 {
-    char debug_str[40];
+    char debug_str[40] = {0};
     char *ptr;
 
     if (count >= sizeof(debug_str)) {

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl-psample.h
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl-psample.h
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-genl/bcm-genl.c
+++ b/systems/linux/kernel/modules/bcm-genl/bcm-genl.c
@@ -1,6 +1,6 @@
 /*
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/bcm-knet/Makefile
+++ b/systems/linux/kernel/modules/bcm-knet/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.3 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.
@@ -76,7 +76,7 @@ $(KMODULE): $(SRCS_COMPOSING)
 	cp ./*.c $(BLDDIR)/
 	cp ../shared/*.c $(BLDDIR)/
 	cat ${KBUILD_EXTRA_SYMBOLS} > $(BLDDIR)/Module.symvers
-	MOD_OBJS=$(OBJECTS_COMPOSING) MOD_NAME=$(THIS_MOD_NAME) KBUILD_EXTRA_SYMBOLS="${KBUILD_EXTRA_SYMBOLS}" $(MAKE) -C $(BLDDIR) $(THIS_MOD_NAME).ko LOC_BLDDIR=$(BLDDIR) LOC_SRCDIR=$(PWD)
+	MOD_OBJS=$(OBJECTS_COMPOSING) MOD_NAME=$(THIS_MOD_NAME) $(MAKE) -C $(BLDDIR) $(THIS_MOD_NAME).ko LOC_BLDDIR=$(BLDDIR) LOC_SRCDIR=$(PWD)
 # }
 else
 # {

--- a/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
+++ b/systems/linux/kernel/modules/bcm-knet/bcm-knet.c
@@ -1,5 +1,6 @@
 /*
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ *
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.
@@ -186,7 +187,8 @@ MODULE_PARM_DESC(mirror_local,
 /*
  * Force to add one layer of VLAN tag to untagged packets on Dune devices
  */
-#if defined(SAI_FIXUP) && defined(BCM_DNX_SUPPORT)  /* SONIC-16195 CS9129167 - Change the default to NOT add tag */
+#if defined(SAI_FIXUP) && defined(BCM_DNX_SUPPORT)
+/* SONIC-16195 CS9129167 - Change the default to NOT add tag */
 static int force_tagged = 0;
 #else
 static int force_tagged = 1;
@@ -1317,8 +1319,9 @@ bkn_sleep(int clicks)
  * PAXB_0_INTC_SET_INTR_ENABLE_REG5r sets interrupt enable bit for interrupts 191 down to 160
  * Packet DMA interrupt enable bit is [168 : 199], here bit [168 : 183] is considered because it is assumed that only cmc0
  */
-#define PAXB_0_INTC_SET_INTR_ENABLE_REG5r   0x0292D114
-#define PAXB_0_INTC_INTR_RAW_STATUS_REG5r   0x0292D18C
+#define PAXB_0_INTC_SET_INTR_ENABLE_REG5r       0x0292D114
+#define PAXB_0_INTC_CLEAR_INTR_ENABLE_REG5r     0x0292D13C
+#define PAXB_0_INTC_INTR_RAW_STATUS_REG5r       0x0292D18C
 
 
 /* CMICR interrupts reserved for kernel handler */
@@ -2205,7 +2208,8 @@ xgsr_irq_fmask_get(bkn_switch_info_t *sinfo, uint32_t *fmask)
 static inline void
 xgsr_irq_mask_set(bkn_switch_info_t *sinfo, uint32_t mask)
 {
-    uint32_t irq_mask_reg = PAXB_0_INTC_SET_INTR_ENABLE_REG5r;
+    uint32_t irq_mask_set_reg = PAXB_0_INTC_SET_INTR_ENABLE_REG5r;
+    uint32_t irq_mask_clear_set_reg = PAXB_0_INTC_CLEAR_INTR_ENABLE_REG5r;
     uint32_t fmask = CMICR_TXRX_IRQ_MASK;
 
     if ((sinfo->base_id & 0x8000) == 0x8000)  {
@@ -2226,7 +2230,8 @@ xgsr_irq_mask_set(bkn_switch_info_t *sinfo, uint32_t mask)
     }
 
     lkbde_irq_mask_set(sinfo->dev_no | LKBDE_ISR2_DEV | LKBDE_IPROC_REG,
-                       irq_mask_reg, mask, fmask);
+                       irq_mask_set_reg, mask, fmask);
+    lkbde_irq_clear_set(sinfo->dev_no | LKBDE_ISR2_DEV | LKBDE_IPROC_REG, irq_mask_clear_set_reg);
 }
 
 static inline void

--- a/systems/linux/kernel/modules/bcm-ptp-clock/bcm-ptp-clock.c
+++ b/systems/linux/kernel/modules/bcm-ptp-clock/bcm-ptp-clock.c
@@ -519,6 +519,7 @@ typedef struct bksync_bs_info_s {
     u32 bc;
     u32 hb;
     bksync_time_spec_t offset;
+    u32 protocol;
 } bksync_bs_info_t;
 
 typedef struct bksync_gpio_info_s {
@@ -2521,7 +2522,8 @@ bksync_dnx_ase1588_tsh_hdr_update(bksync_dev_t *dev_info, struct sk_buff *skb, i
             ptp_hdr_offset -= BKSYNC_DNXJR2_MODULE_HEADER_LEN;
         }
         else {
-            ptp_hdr_offset -= (BKSYNC_DNXJR2_MODULE_HEADER_LEN + BKSYNC_DNX_PTCH_2_SIZE + BKSYNC_DNXJR2_ITMH_HEADER_LEN);
+            ptp_hdr_offset -= (BKSYNC_DNXJR2_MODULE_HEADER_LEN + BKSYNC_DNX_PTCH_2_SIZE + BKSYNC_DNXJR2_ITMH_HEADER_LEN +
+                                    BKSYNC_DNXJR2_FTMH_APP_SPECIFIC_EXT_LEN + BKSYNC_DNXJR2_TSH_HDR_SIZE);
         }
 
     /* Inserting TSH and ASE before PPH and UDH - shifted PPH and UDH by 13 bytes in skb->data */
@@ -3076,6 +3078,7 @@ static int bksync_broadsync_cmd(bksync_dev_t *dev_info, int bs_id)
     subcmd = (bs_id == 0) ? BKSYNC_BROADSYNC_BS0_CONFIG : BKSYNC_BROADSYNC_BS1_CONFIG;
 
     subcmd_data =  ((dev_info->bksync_bs_info[bs_id]).enable & 0x1);
+    subcmd_data |= (((dev_info->bksync_bs_info[bs_id]).protocol & 0x1) << 1);
     subcmd_data |= (((dev_info->bksync_bs_info[bs_id]).mode & 0x1) << 8);
     subcmd_data |= ((dev_info->bksync_bs_info[bs_id]).hb << 16);
     subcmd_data |= (((u64)(dev_info->bksync_bs_info[bs_id]).bc) << 32);
@@ -3439,7 +3442,7 @@ static ssize_t
 bksync_proc_txts_write(struct file *file, const char *buf,
                       size_t count, loff_t *loff)
 {
-    char debug_str[40];
+    char debug_str[40] = {0};
     char *ptr;
     int port;
     int dev_no;
@@ -3494,7 +3497,7 @@ static ssize_t
 bksync_proc_debug_write(struct file *file, const char *buf,
                       size_t count, loff_t *loff)
 {
-    char debug_str[40];
+    char debug_str[40] = {0};
     char *ptr;
 
     if (copy_from_user(debug_str, buf, count)) {
@@ -3672,6 +3675,7 @@ static ssize_t bs_attr_store(struct kobject *kobj,
     int dev_no = -1;
     bksync_dev_t *dev_info = NULL;
     bksync_time_spec_t offset = {0};
+    int protocol = 0;
 
     if (ATTRCMP(bs0)) {
         bs_id = 0;
@@ -3691,13 +3695,14 @@ static ssize_t bs_attr_store(struct kobject *kobj,
 
     dev_info = &ptp_priv->dev_info[dev_no];
 
-    ret = sscanf(buf, "enable:%d mode:%d bc:%u hb:%u sign:%d offset:%llu.%u", &enable, &mode, &bc, &hb, &offset.sign, &offset.sec, &offset.nsec);
-    DBG_VERB(("rd:%d bs0: enable:%d mode:%d bc:%d hb:%d sign:%d offset:%llu.%u\n", rd_iter++, enable, mode, bc, hb, offset.sign, offset.sec, offset.nsec));
+    ret = sscanf(buf, "enable:%d mode:%d bc:%u hb:%u sign:%d offset:%llu.%u protocol:%d", &enable, &mode, &bc, &hb, &offset.sign, &offset.sec, &offset.nsec, &protocol);
+    DBG_VERB(("rd:%d bs0: enable:%d mode:%d bc:%d hb:%d sign:%d offset:%llu.%u protocol:%d\n", rd_iter++, enable, mode, bc, hb, offset.sign, offset.sec, offset.nsec, protocol));
 
     dev_info->bksync_bs_info[bs_id].enable = enable;
     dev_info->bksync_bs_info[bs_id].mode = mode;
     dev_info->bksync_bs_info[bs_id].bc = bc;
     dev_info->bksync_bs_info[bs_id].hb = hb;
+    dev_info->bksync_bs_info[bs_id].protocol = protocol;
 
     (void)bksync_broadsync_cmd(dev_info, bs_id);
 
@@ -3741,7 +3746,7 @@ static ssize_t bs_attr_show(struct kobject *kobj,
 
     variance = (status >> 32);
     status = (status & 0xFFFFFFFF);
-    bytes = sprintf(buf, "enable:%d mode:%d bc:%u hb:%u sign:%d offset:%llu.%u status:%u(%u)\n",
+    bytes = sprintf(buf, "enable:%d mode:%d bc:%u hb:%u sign:%d offset:%llu.%u protocol:%d status:%u(%u)\n",
             dev_info->bksync_bs_info[bs_id].enable,
             dev_info->bksync_bs_info[bs_id].mode,
             dev_info->bksync_bs_info[bs_id].bc,
@@ -3749,9 +3754,10 @@ static ssize_t bs_attr_show(struct kobject *kobj,
             dev_info->bksync_bs_info[bs_id].offset.sign,
             dev_info->bksync_bs_info[bs_id].offset.sec,
             dev_info->bksync_bs_info[bs_id].offset.nsec,
+            dev_info->bksync_bs_info[bs_id].protocol,
             (u32)status,
             variance);
-    DBG_VERB(("wr:%d bs1: enable:%d mode:%d bc:%u hb:%u sign:%d offset:%llu.%u status:%u(%u)\n",
+    DBG_VERB(("wr:%d bs1: enable:%d mode:%d bc:%u hb:%u sign:%d offset:%llu.%u protocol:%d status:%u(%u)\n",
                 wr_iter++,
                 dev_info->bksync_bs_info[bs_id].enable,
                 dev_info->bksync_bs_info[bs_id].mode,
@@ -3760,6 +3766,7 @@ static ssize_t bs_attr_show(struct kobject *kobj,
                 dev_info->bksync_bs_info[bs_id].offset.sign,
                 dev_info->bksync_bs_info[bs_id].offset.sec,
                 dev_info->bksync_bs_info[bs_id].offset.nsec,
+                dev_info->bksync_bs_info[bs_id].protocol,
                 (u32)status,
                 variance));
 
@@ -4614,6 +4621,7 @@ bksync_ioctl_cmd_handler(kcom_msg_clock_cmd_t *kmsg, int len, int dcb_type, int 
             dev_info->bksync_bs_info[bs_id].mode = kmsg->clock_info.data[1];
             dev_info->bksync_bs_info[bs_id].bc = kmsg->clock_info.data[2];
             dev_info->bksync_bs_info[bs_id].hb = kmsg->clock_info.data[3];
+            dev_info->bksync_bs_info[bs_id].protocol = kmsg->clock_info.data[4];
 
             (void)bksync_broadsync_cmd(dev_info, bs_id);
             break;

--- a/systems/linux/kernel/modules/genl-packet/Makefile
+++ b/systems/linux/kernel/modules/genl-packet/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.3 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/kernel/modules/include/bcm-knet.h
+++ b/systems/linux/kernel/modules/include/bcm-knet.h
@@ -1,7 +1,7 @@
 /*
  * $Id: bcm-knet.h,v 1.4 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/include/gmodule.h
+++ b/systems/linux/kernel/modules/include/gmodule.h
@@ -1,7 +1,7 @@
 /*
  * $Id: gmodule.h,v 1.9 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/include/lkm.h
+++ b/systems/linux/kernel/modules/include/lkm.h
@@ -1,7 +1,7 @@
 /*
  * $Id: lkm.h,v 1.22 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/knet-cb/Makefile
+++ b/systems/linux/kernel/modules/knet-cb/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.3 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/kernel/modules/knet-cb/knet-cb.c
+++ b/systems/linux/kernel/modules/knet-cb/knet-cb.c
@@ -1,5 +1,6 @@
 /*
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ *
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/kernel/modules/shared/Makefile
+++ b/systems/linux/kernel/modules/shared/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.2 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/kernel/modules/shared/gmodule.c
+++ b/systems/linux/kernel/modules/shared/gmodule.c
@@ -1,7 +1,7 @@
 /*
  * $Id: gmodule.c,v 1.20 Broadcom SDK $
  *
- * $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+ * $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
  * 
  * Permission is granted to use, copy, modify and/or distribute this
  * software under either one of the licenses below.

--- a/systems/linux/user/common/Makefile
+++ b/systems/linux/user/common/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.4 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.
@@ -70,6 +70,7 @@ KERN_BLDROOT=${SDK}/${SDKBUILD}/${BLDCONFIG}/$(kernel-override)$(bldroot_suffix)
 else
 ifdef SDK_OUTDIR
 KERN_BLDROOT=${SDK_OUTDIR}/${SDKBUILD}/$(kernel-override)$(bldroot_suffix)
+OUTPUT_DIR=${SDK_OUTDIR}/${SDKBUILD}
 else
 KERN_BLDROOT=${SDK}/${SDKBUILD}/$(kernel-override)$(bldroot_suffix)
 endif
@@ -91,6 +92,16 @@ endif
 
 ifeq ($(DEST_DIR),)
 DEST_DIR=${BLDDIR}
+endif
+
+# Support quiet make
+ifneq (,$(findstring s,$(MAKEFLAGS)))
+export quiet = quiet_
+export KBUILD_VERBOSE = 1
+endif
+
+ifndef KDIR
+export KDIR=$(KERNDIR)
 endif
 
 KERNEL_BDE_LOCAL := linux-kernel-bde.$(KOBJ)
@@ -116,6 +127,12 @@ BCM_GENL := $(DEST_DIR)/$(BCM_GENL_LOCAL)
 BCM_KNET_LOCAL := linux-bcm-knet.$(KOBJ)
 BCM_KNET := $(DEST_DIR)/$(BCM_KNET_LOCAL)
 
+BCM_NGKNET_LOCAL := linux-ngknet.$(KOBJ)
+BCM_NGKNET := $(DEST_DIR)/$(BCM_NGKNET_LOCAL)
+
+NGKNETCB_LOCAL := linux-ngknetcb.$(KOBJ)
+NGKNETCB := $(DEST_DIR)/$(NGKNETCB_LOCAL)
+
 ifeq (,$(findstring DELIVER,$(MAKECMDGOALS)))
 .DEFAULT_GOAL := all
 all_targets := kernel_modules $(KERNEL_BDE) $(USER_BDE)
@@ -132,6 +149,13 @@ endif
 ifndef BUILD_KNET
 BUILD_KNET = 1
 endif
+
+ifndef BUILD_NGKNET
+BUILD_NGKNET = 0
+endif
+
+#Skip building NGKNET_CB
+BUILD_NGKNET_CB = 0
 
 ifeq ($(BUILD_KNET),1)
 # Kernel network support
@@ -179,6 +203,42 @@ ADD_TO_CFLAGS += -I$(SDK)/systems/linux/kernel/modules/include
 COND_KNET_LIBS = libuser.$(libext)
 endif
 
+ifeq (1,$(BUILD_NGKNET))
+# Kernel network support
+all_targets += $(BCM_NGKNET)
+knet_subdirs += bcm-ngknet
+
+ifeq ($(NO_LOCAL_TARGETS),)
+LOCAL_TARGETS +=$(patsubst %,../$(platform)/%,$(BCM_NGKNET_LOCAL))
+all_targets +=$(LOCAL_TARGETS)
+endif
+
+ifeq (1,$(BUILD_NGKNET_CB))
+all_targets += $(NGKNETCB)
+knet_subdirs += ngknetcb
+
+ifeq ($(NO_LOCAL_TARGETS),)
+LOCAL_TARGETS +=$(patsubst %,../$(platform)/%,$(NGKNETCB_LOCAL))
+all_targets +=$(LOCAL_TARGETS)
+endif
+
+ifdef KPMD
+KPMD_OPT := KPMD=1
+endif
+endif
+endif
+
+ifeq (1,$(BUILD_NGKNET))
+NGKNET_BDE_BLDDIR = $(KERN_BLDROOT)/systems/bde/linux/kernel/kernel_module
+NGKNET_LKM_BLDROOT = $(KERN_BLDROOT)/systems/linux/kernel/modules/bcm-ngknet
+NGKNET_BLDDIR = $(NGKNET_LKM_BLDROOT)
+endif # BUILD_NGKNET
+
+ifeq (1,$(BUILD_NGKNET_CB))
+NGKNETCB_LKM_BLDROOT = $(KERN_BLDROOT)/systems/linux/kernel/modules/ngknetcb
+NGKNETCB_BLDDIR = $(NGKNETCB_LKM_BLDROOT)
+endif # BUILD_NGKNET_CB
+
 all: $(BLDDIR)/.tree $(all_targets)
 
 ifeq ($(NO_LOCAL_TARGETS),)
@@ -224,6 +284,18 @@ endif
 		OPT_CFLAGS="$(ADD_TO_KCFLAGS)" override-target=linux-$(platform)
 endif
 endif
+ifeq ($(BUILD_NGKNET),1)
+	$(MAKE) -C $(SDK)/systems/linux/kernel/modules/bcm-ngknet $(OPT_KERNEL_TOOLCHAIN) quiet=$(quiet) LKM_BLDDIR=$(NGKNET_BLDDIR) KBUILD_VERBOSE=$(KBUILD_VERBOSE) \
+		KBUILD_EXTRA_SYMBOLS=$(NGKNET_BDE_BLDDIR)/Module.symvers kernel_version=$(kernel_version) OPT_CFLAGS="$(ADD_TO_KCFLAGS)" \
+		override-target=linux-$(platform)
+	(cd $(KERN_BLDROOT); ln -s -f $(NGKNET_BLDDIR)/*.ko ./)
+ifneq (,$(filter ngknetcb,$(knet_subdirs)))
+	$(MAKE) -C $(SDK)/systems/linux/kernel/modules/ngknetcb $(OPT_KERNEL_TOOLCHAIN) $(KPMD_OPT) quiet=$(quiet) LKM_BLDDIR=$(NGKNETCB_BLDDIR) KBUILD_VERBOSE=$(KBUILD_VERBOSE) \
+		KBUILD_EXTRA_SYMBOLS=$(NGKNET_BLDDIR)/Module.symvers kernel_version=$(kernel_version) OPT_CFLAGS="$(ADD_TO_KCFLAGS)" \
+		override-target=linux-$(platform)
+	(cd $(KERN_BLDROOT); ln -s -f $(NGKNETCB_BLDDIR)/*.ko ./)
+endif
+endif
 
 $(KERNEL_BDE): $(KERN_BLDROOT)/$(KERNEL_BDE_LOCAL)
 	mkdir -p $(@D)
@@ -236,6 +308,12 @@ $(BCM_KNET): $(KERN_BLDROOT)/$(BCM_KNET_LOCAL)
 	$(OBJCOPY) --strip-debug $< $@
 
 $(KNET_CB): $(KERN_BLDROOT)/$(KNET_CB_LOCAL)
+	$(OBJCOPY) --strip-debug $< $@
+
+$(BCM_NGKNET): $(KERN_BLDROOT)/$(BCM_NGKNET_LOCAL)
+	$(OBJCOPY) --strip-debug $< $@
+
+$(NGKNETCB): $(KERN_BLDROOT)/$(NGKNETCB_LOCAL)
 	$(OBJCOPY) --strip-debug $< $@
 
 $(GENL_PACKET): $(KERN_BLDROOT)/$(GENL_PACKET_LOCAL)
@@ -259,10 +337,18 @@ clean::
 		override-target=linux-$(platform) $@
 	$(RM) $(KERNEL_BDE) $(USER_BDE)
 	$(RM) $(BCM_KNET) $(KNET_CB) $(GENL_PACKET) $(BCM_GENL)
+ifdef BUILD_NGKNET
+	$(RM) $(BCM_NGKNET)
+endif
+ifdef BUILD_NGKNET_CB
+	$(RM) $(NGKNETCB)
+endif
 	$(RM) $(KERN_BLDROOT)/$(KERNEL_BDE_LOCAL)
 	$(RM) $(KERN_BLDROOT)/$(USER_BDE_LOCAL)
 	$(RM) $(KERN_BLDROOT)/$(BCM_KNET_LOCAL)
 	$(RM) $(KERN_BLDROOT)/$(KNET_CB_LOCAL)
+	$(RM) $(KERN_BLDROOT)/$(BCM_NGKNET_LOCAL)
+	$(RM) $(KERN_BLDROOT)/$(NGKNETCB_LOCAL)
 	$(RM) $(KERN_BLDROOT)/$(GENL_PACKET_LOCAL)
 	$(RM) $(KERN_BLDROOT)/$(BCM_GENL_LOCAL)
 	$(RM) $(LOCAL_TARGETS)

--- a/systems/linux/user/gts/Makefile
+++ b/systems/linux/user/gts/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/user/iproc-3_14/Makefile
+++ b/systems/linux/user/iproc-3_14/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.7 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/user/iproc-4_4/Makefile
+++ b/systems/linux/user/iproc-4_4/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.7 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/user/iproc/Makefile
+++ b/systems/linux/user/iproc/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.7 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.
@@ -54,7 +54,7 @@ endif
 
 export SDK
 
-override kernel_version=6_6
+override kernel_version=6_12
 platform=iproc
 
 IPROC_BUILD=1

--- a/systems/linux/user/iproc_64/Makefile
+++ b/systems/linux/user/iproc_64/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.7 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.
@@ -54,7 +54,7 @@ endif
 
 export SDK
 
-override kernel_version=6_6
+override kernel_version=6_12
 platform=iproc_64
 
 IPROC_BUILD=1

--- a/systems/linux/user/slk/Makefile
+++ b/systems/linux/user/slk/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/user/x86-5_10/Makefile
+++ b/systems/linux/user/x86-5_10/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/user/x86-64-fc28/Makefile
+++ b/systems/linux/user/x86-64-fc28/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/user/x86-smp_generic_64-2_6/Makefile
+++ b/systems/linux/user/x86-smp_generic_64-2_6/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 1.2 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/systems/linux/user/xlr/Makefile
+++ b/systems/linux/user/xlr/Makefile
@@ -1,7 +1,7 @@
 # -*- Makefile -*-
 # $Id: Makefile,v 0.1 Broadcom SDK $
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.

--- a/tools/mktool.pl
+++ b/tools/mktool.pl
@@ -4,7 +4,7 @@
 # $Id: mktool.pl,v 1.5 Broadcom SDK $
 # 
 #
-# $Copyright: 2017-2025 Broadcom Inc. All rights reserved.
+# $Copyright: 2017-2026 Broadcom Inc. All rights reserved.
 # 
 # Permission is granted to use, copy, modify and/or distribute this
 # software under either one of the licenses below.


### PR DESCRIPTION
Bump up saibcm-modules to SDK-6.5.35-dnx-gpl required for SAI 15.2.